### PR TITLE
Allow to override download URL

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,9 +14,19 @@ minio_layouts:
 minio_server_bin: /usr/local/bin/minio
 minio_client_bin: /usr/local/bin/mc
 
-# Minio release to install. default if lastet
+# Define version and origin (mutual exclusive)
+#
+# (A) Minio release version (default: latest)
 minio_server_release: ""
 minio_client_release: ""
+#
+# (B) Full download URL
+minio_server_artifact_url: ""
+minio_client_artifact_url: ""
+# Optional
+# Format: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html#parameter-checksum
+minio_server_artifact_checksum: ""
+minio_client_artifact_checksum: ""
 
 # Runtime user and group for the Minio server service
 minio_user: minio

--- a/molecule/layouts/playbook.yml
+++ b/molecule/layouts/playbook.yml
@@ -2,6 +2,11 @@
 
 - hosts: all
   any_errors_fatal: true
+  vars:
+    minio_server_artifact_url: https://dl.min.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2020-10-28T08-16-50Z
+    minio_server_artifact_checksum: sha256:2c7e6774a9befbba6a126791f363550f8f14e34008e100d0e0e57e2ad9b2ab8c
+    minio_client_artifact_url: https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2020-10-03T02-54-56Z
+    minio_client_artifact_checksum: sha256:59e184bd4e2c3a8a19837b0f0da3977bd4e301495a24e4a5d50e291728a1de51
   roles:
     - role: ansible-minio
       vars:

--- a/tasks/install-client.yml
+++ b/tasks/install-client.yml
@@ -1,22 +1,32 @@
 ---
 
-- name: Compose the Minio client download base url
+- name: "Set the Minio client download url to default"
   set_fact:
-    _minio_client_download_base_url: "https://dl.minio.io/client/mc/release/linux-{{ go_arch }}"
-
-- name: Compose the Minio client download url with lastest release
-  set_fact:
-    _minio_client_download_url: "{{ _minio_client_download_base_url }}/mc"
-  when: minio_client_release | length == 0
+    _minio_client_download_url: "{{ minio_default_client_artifact_url }}"
 
 - name: "Compose the Minio client download url with release {{ minio_client_release }}"
   set_fact:
-    _minio_client_download_url: "{{ _minio_client_download_base_url }}/archive/mc.{{ minio_client_release }}"
-  when: minio_client_release | length > 0
+    _minio_client_download_url: "{{ minio_default_client_artifact_url }}.{{ minio_client_release }}"
+  when:
+    - minio_client_release | length > 0
+    - minio_client_artifact_url | length == 0
+
+- name: "Override the Minio client download url"
+  set_fact:
+    _minio_client_download_url: "{{ minio_client_artifact_url }}"
+  when:
+    - minio_client_artifact_url | length > 0
+    - minio_client_release | length == 0
 
 - name: "Get the Minio client checksum for {{ go_arch }} architecture"
   set_fact:
-    _minio_client_checksum: "{{ lookup('url', _minio_client_download_url + '.sha256sum').split(' ')[0] }}"
+    _minio_client_checksum: "sha256:{{ lookup('url', _minio_client_download_url + '.sha256sum').split(' ')[0] }}"
+  when: minio_client_artifact_checksum | length == 0
+
+- name: "Override the Minio client  checksum"
+  set_fact:
+    _minio_client_checksum: "{{ minio_client_artifact_checksum }}"
+  when: minio_client_artifact_checksum | length > 0
 
 - name: Download the Minio client
   get_url:
@@ -25,7 +35,7 @@
     owner: "root"
     group: "root"
     mode: 0755
-    checksum: "sha256:{{ _minio_client_checksum }}"
+    checksum: "{{ _minio_client_checksum }}"
   register: _download_client
   until: _download_client is succeeded
   retries: 5

--- a/tasks/install-server.yml
+++ b/tasks/install-server.yml
@@ -1,21 +1,31 @@
 ---
-- name: Compose the Minio server download base url
+- name: "Set the Minio server download url to default"
   set_fact:
-    _minio_server_download_base_url: "https://dl.minio.io/server/minio/release/linux-{{ go_arch }}"
-
-- name: Compose the Minio server download url with lastest release
-  set_fact:
-    _minio_server_download_url: "{{ _minio_server_download_base_url }}/minio"
-  when: minio_server_release | length == 0
+    _minio_server_download_url: "{{ minio_default_server_artifact_url }}"
 
 - name: "Compose the Minio server download url with release {{ minio_server_release }}"
   set_fact:
-    _minio_server_download_url: "{{ _minio_server_download_base_url }}/archive/minio.{{ minio_server_release }}"
-  when: minio_server_release | length > 0
+    _minio_server_download_url: "{{ minio_default_server_artifact_url }}.{{ minio_server_release }}"
+  when:
+    - minio_server_release | length > 0
+    - minio_server_artifact_url | length == 0
+
+- name: "Override the Minio server download url"
+  set_fact:
+    _minio_server_download_url: "{{ minio_server_artifact_url }}"
+  when:
+    - minio_server_artifact_url | length > 0
+    - minio_server_release | length == 0
 
 - name: "Get the Minio server checksum for {{ go_arch }} architecture"
   set_fact:
-    _minio_server_checksum: "{{ lookup('url', _minio_server_download_url + '.sha256sum').split(' ')[0] }}"
+    _minio_server_checksum: "sha256:{{ lookup('url', _minio_server_download_url + '.sha256sum').split(' ')[0] }}"
+  when: minio_server_artifact_checksum | length == 0
+
+- name: "Override the Minio server checksum"
+  set_fact:
+    _minio_server_checksum: "{{ minio_server_artifact_checksum }}"
+  when: minio_server_artifact_checksum | length > 0
 
 - name: "Set service name"
   set_fact:
@@ -108,7 +118,7 @@
     owner: "root"
     group: "root"
     mode: 0755
-    checksum: "sha256:{{ _minio_server_checksum }}"
+    checksum: "{{ _minio_server_checksum }}"
   register: _download_server
   until: _download_server is succeeded
   retries: 5

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,3 +7,6 @@ go_arch_map:
   armv6l: 'arm6vl'
 
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
+
+minio_default_server_artifact_url: "https://dl.minio.io/server/minio/release/linux-{{ go_arch }}/minio"
+minio_default_client_artifact_url: "https://dl.minio.io/client/mc/release/linux-{{ go_arch }}/mc"


### PR DESCRIPTION
By setting minio_[server,client]_artifact_url one can completely
change where the mino components are being downloaded from.