### PR TITLE
Fix minio service not starting properly

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,10 +5,19 @@ minio_layouts:
   server1:
     server_addr: ":9091"
   # server_datadir: String
-# The second minio instance on this server.
-  server2:
-    server_addr: ":9092"
-  # server_datadir: String
+#
+# The second minio instance on this server may look like.
+# server2:
+#   server_addr: ":9092"
+#   server_datadir: String
+
+# NOTE: to configure more instances on the same host, apply role multiple times
+# Control which layout is used every time the role is applied
+# minio_layout: String
+
+# It's impossible to definitively determine the group name from the host
+# this role is applied to, thus it can be overridden
+minio_group_name: "minio"
 
 # Minio binaries path
 minio_server_bin: /usr/local/bin/minio

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,3 +9,10 @@
   service:
     name: "{{ _minio_service_name }}"
     state: restarted
+
+- name: verify minio is responsive
+  uri:
+    url: "http://127.0.0.1{{ minio_server_addr }}/minio/health/live"
+    timeout: 6
+  register: response
+  failed_when: response.status != 200

--- a/molecule/layouts/playbook.yml
+++ b/molecule/layouts/playbook.yml
@@ -7,6 +7,13 @@
     minio_server_artifact_checksum: sha256:2c7e6774a9befbba6a126791f363550f8f14e34008e100d0e0e57e2ad9b2ab8c
     minio_client_artifact_url: https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2020-10-03T02-54-56Z
     minio_client_artifact_checksum: sha256:59e184bd4e2c3a8a19837b0f0da3977bd4e301495a24e4a5d50e291728a1de51
+    minio_layouts:
+      server1:
+        server_addr: ":9091"
+      server2:
+        server_addr: ":9092"
+    minio_access_key: "key"
+    minio_secret_key: "seecreet"
   roles:
     - role: ansible-minio
       vars:

--- a/molecule/resources/create.yml
+++ b/molecule/resources/create.yml
@@ -5,6 +5,13 @@
   gather_facts: false
   no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   tasks:
+    - name: Create docker network(s)
+      docker_network:
+        name: "{{ item }}"
+        state: present
+        scope: local
+      with_items: "{{ molecule_yml.platforms | molecule_get_docker_networks }}"
+
     - name: Create molecule instance(s)
       docker_container:
         name: "{{ item.name }}"

--- a/tasks/install-server.yml
+++ b/tasks/install-server.yml
@@ -46,7 +46,7 @@
     minio_server_cluster_nodes: >-
       [
         {%- for layout in minio_layouts -%}
-          {%- for host in groups['minio'] -%}
+          {%- for host in groups[minio_group_name] -%}
             "{{
               [
                 'http://',
@@ -75,7 +75,7 @@
 
 - name: "Override environment file if layout name is defined"
   set_fact:
-    minio_server_envfile: "minio-{{ minio_layout }}"
+    minio_server_envfile: "/etc/default/minio-{{ minio_layout }}"
   when: minio_layout is defined and minio_layout | length > 0
 
 - name: "Override server address if layout name is defined"
@@ -88,6 +88,14 @@
     minio_server_datadirs:
       - "{{ minio_layouts[minio_layout]['server_datadir'] | default('/var/lib/minio-' + minio_layout) }}"
   when: minio_layout is defined and minio_layout | length > 0
+
+- name: "Check whether minio runs in distributed mode"
+  assert:
+    that:
+      - minio_access_key | length >= 3
+      - minio_secret_key | length >= 8
+    msg: "Running in distributed mode. Please define access_key and secret_key."
+  when: minio_server_cluster_nodes | length > 1
 
 - name: Create Minio group
   group:
@@ -123,7 +131,9 @@
   until: _download_server is succeeded
   retries: 5
   delay: 2
-  notify: restart minio
+  notify:
+    - restart minio
+    - verify minio is responsive
 
 
 - name: cluster dump
@@ -137,7 +147,9 @@
     owner: "root"
     group: "{{ minio_group }}"
     mode: 0640
-  notify: restart minio
+  notify:
+    - restart minio
+    - verify minio is responsive
 
 - name: Create the Minio server systemd config
   template:
@@ -149,6 +161,7 @@
   notify:
     - reload minio systemd
     - restart minio
+    - verify minio is responsive
 
 - name: Create the Minio server init.d config
   template:
@@ -158,7 +171,9 @@
     group: "root"
     mode: 0750
   when: ansible_service_mgr != "systemd"
-  notify: restart minio
+  notify:
+    - restart minio
+    - verify minio is responsive
 
 - name: Enable and start the Minio service
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,3 +12,7 @@
 
 - include_tasks: install-client.yml
   when: minio_install_client
+
+# NOTE: handlers a triggered at *play* level not at the end of a role assignment
+# ISSUE: https://github.com/ansible/ansible/issues/15476
+- meta: flush_handlers


### PR DESCRIPTION
This change set aims to address two main issues:

1. 'minio_server_envfile' was not correct, which caused minio not being
   configured properly and thus not to start
2. when minio runs in a distributed way (two instances on one machine
   already counts), it requires secret and access key to have a certain
   length

Additionally, some defaults and their comments have been fixed. In order to use
minio_layouts length in control flow, one is now commented out. This allows to
keep using the role for a single-node-instance installation.
Furthermore, another handler is introduced to do a small integration test at the
end.

Molecule: When destroying the test deployment, possible networks are already being
removed. For unknown reasons adding them during creation step was missing. This was
used during development.