### PR TITLE
Migrate test code and dependencies to Molecule v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,16 @@
 
 # Ansible Role: Minio
 
-[![Build Status](https://travis-ci.org/atosatto/ansible-minio.svg?branch=master)](https://travis-ci.org/atosatto/ansible-minio)
+[![Build Status](https://travis-ci.org/atosatto/ansible-minio.svg?branch=master)](https://travis-ci.org/wireapp/ansible-minio)
 [![License](https://img.shields.io/badge/license-MIT%20License-brightgreen.svg)](https://opensource.org/licenses/MIT)
-[![Ansible Role](https://img.shields.io/badge/ansible%20role-atosatto.minio-blue.svg)](https://galaxy.ansible.com/atosatto/minio/)
-[![GitHub tag](https://img.shields.io/github/tag/atosatto/ansible-minio.svg)](https://github.com/atosatto/ansible-minio/tags)
+[![GitHub tag](https://img.shields.io/github/tag/atosatto/ansible-minio.svg)](https://github.com/wireapp/ansible-minio/tags)
 
 Install and configure the [Minio](https://minio.io/) S3 compatible object storage server
 on RHEL/CentOS and Debian/Ubuntu.
 
 ## Requirements
 
-None.
+Ansible: `ansible >= 2.8, < 2.9`
 
 ## Role Variables
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,5 @@
 galaxy_info:
+  role_name: minio
   author: Andrea Tosatto
   description: Install and configure the Minio S3 compatible object storage server on RHEL/CentOS and Debian/Ubuntu
   min_ansible_version: 2.1

--- a/molecule/alternative/molecule.yml
+++ b/molecule/alternative/molecule.yml
@@ -6,8 +6,7 @@ scenario:
 driver:
   name: docker
 
-dependency:
-  name: galaxy
+dependency: {}
 
 platforms:
   - name: minio-centos-7
@@ -44,12 +43,12 @@ provisioner:
     diff: True
     v: True
   playbooks:
-    create: ../resources/create.yml
     prepare: ../resources/prepare.yml
-    destroy: ../resources/destroy.yml
+    converge: ./playbook.yml
 
-lint:
-  name: yamllint
+lint: |
+  set -e
+  ansible-lint
 
 verifier:
   name: testinfra
@@ -57,5 +56,3 @@ verifier:
     vvv: True
   additional_files_or_dirs:
     - ../resources/tests/
-  lint:
-    name: flake8

--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -4,7 +4,13 @@
   any_errors_fatal: true
   roles:
     - ansible-minio
+  vars_files:
+    - ./../resources/vars.yml
   vars:
+    minio_server_artifact_url: https://dl.min.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2021-03-17T02-33-02Z
+    minio_server_artifact_checksum: sha256:475f878614021769dba33fc051124834ac2131b52e52794f83f7c21aea51444a
+    minio_client_artifact_url: https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2021-03-23T05-46-11Z
+    minio_client_artifact_checksum: sha256:088efeb053cdb06f8450533452ad0fae859758134a953cb353072236d2abb4ee
     minio_server_envfile: "/opt/minio"
     minio_server_addr: ":80"
     minio_server_datadirs:

--- a/molecule/alternative/tests/test_minio_alternative.py
+++ b/molecule/alternative/tests/test_minio_alternative.py
@@ -10,7 +10,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 @pytest.fixture()
 def AnsibleDefaults():
-    with open('../../defaults/main.yml', 'r') as stream:
+    dir_path = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(dir_path, './../../../defaults/main.yml'), 'r') as stream:
         return yaml.load(stream)
 
 
@@ -21,7 +22,7 @@ def test_minio_server_env_file(host, AnsibleDefaults):
     assert f.exists
     assert f.user == 'root'
     assert f.group == AnsibleDefaults['minio_group']
-    assert oct(f.mode) == '0640'
+    assert oct(f.mode) == '0o640'
 
 
 @pytest.mark.parametrize('minio_datadir', [
@@ -37,7 +38,7 @@ def test_minio_server_data_directories(host, AnsibleDefaults, minio_datadir):
     assert d.exists
     assert d.user == AnsibleDefaults['minio_user']
     assert d.group == AnsibleDefaults['minio_group']
-    assert oct(d.mode) == '0750'
+    assert oct(d.mode) == '0o750'
 
 
 def test_minio_server_webserver(host):

--- a/molecule/cluster/molecule.yml
+++ b/molecule/cluster/molecule.yml
@@ -6,8 +6,7 @@ scenario:
 driver:
   name: docker
 
-dependency:
-  name: galaxy
+dependency: {}
 
 platforms:
   - name: minio-centos-7
@@ -44,12 +43,12 @@ provisioner:
     diff: True
     v: True
   playbooks:
-    create: ../resources/create.yml
     prepare: ../resources/prepare.yml
-    destroy: ../resources/destroy.yml
+    converge: ./playbook.yml
 
-lint:
-  name: yamllint
+lint: |
+  set -e
+  ansible-lint
 
 verifier:
   name: testinfra
@@ -57,5 +56,3 @@ verifier:
     vvv: True
   additional_files_or_dirs:
     - ../resources/tests/
-  lint:
-    name: flake8

--- a/molecule/cluster/playbook.yml
+++ b/molecule/cluster/playbook.yml
@@ -4,6 +4,8 @@
   any_errors_fatal: true
   roles:
     - ansible-minio
+  vars_files:
+    - ./../resources/vars.yml
   vars:
     minio_server_datadirs:
       - "/test1"

--- a/molecule/cluster/tests/test_minio_cluster.py
+++ b/molecule/cluster/tests/test_minio_cluster.py
@@ -10,7 +10,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 @pytest.fixture()
 def AnsibleDefaults():
-    with open('../../defaults/main.yml', 'r') as stream:
+    dir_path = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(dir_path, './../../../defaults/main.yml'), 'r') as stream:
         return yaml.load(stream)
 
 
@@ -27,4 +28,4 @@ def test_directories(host, AnsibleDefaults, minio_datadir):
     assert d.exists
     assert d.user == AnsibleDefaults['minio_user']
     assert d.group == AnsibleDefaults['minio_group']
-    assert oct(d.mode) == '0750'
+    assert oct(d.mode) == '0o750'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,8 +6,7 @@ scenario:
 driver:
   name: docker
 
-dependency:
-  name: galaxy
+dependency: {}
 
 platforms:
   - name: minio-centos-7
@@ -44,12 +43,12 @@ provisioner:
     diff: True
     v: True
   playbooks:
-    create: ../resources/create.yml
-    destroy: ../resources/destroy.yml
     prepare: ../resources/prepare.yml
+    converge: ./playbook.yml
 
-lint:
-  name: yamllint
+lint: |
+  set -e
+  ansible-lint
 
 verifier:
   name: testinfra
@@ -57,5 +56,3 @@ verifier:
     vvv: True
   additional_files_or_dirs:
     - ../resources/tests/
-  lint:
-    name: flake8

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -2,5 +2,7 @@
 
 - hosts: all
   any_errors_fatal: true
+  vars_files:
+    - ./../resources/vars.yml
   roles:
     - ansible-minio

--- a/molecule/default/tests/test_minio_default.py
+++ b/molecule/default/tests/test_minio_default.py
@@ -10,7 +10,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 @pytest.fixture()
 def AnsibleDefaults():
-    with open('../../defaults/main.yml', 'r') as stream:
+    dir_path = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(dir_path, './../../../defaults/main.yml'), 'r') as stream:
         return yaml.load(stream)
 
 
@@ -24,7 +25,7 @@ def test_minio_installed(host, AnsibleDefaults, minio_bin_var):
     assert f.exists
     assert f.user == 'root'
     assert f.group == 'root'
-    assert oct(f.mode) == '0755'
+    assert oct(f.mode) == '0o755'
 
 
 def test_minio_server_data_directories(host, AnsibleDefaults):
@@ -35,7 +36,7 @@ def test_minio_server_data_directories(host, AnsibleDefaults):
         assert d.exists
         assert d.user == AnsibleDefaults['minio_user']
         assert d.group == AnsibleDefaults['minio_group']
-        assert oct(d.mode) == '0750'
+        assert oct(d.mode) == '0o750'
 
 
 def test_minio_server_webserver(host):

--- a/molecule/layouts/molecule.yml
+++ b/molecule/layouts/molecule.yml
@@ -6,8 +6,7 @@ scenario:
 driver:
   name: docker
 
-dependency:
-  name: galaxy
+dependency: {}
 
 platforms:
   - name: instance1
@@ -34,12 +33,12 @@ provisioner:
     diff: True
     v: True
   playbooks:
-    create: ../resources/create.yml
-    destroy: ../resources/destroy.yml
     prepare: ../resources/prepare.yml
+    converge: ./playbook.yml
 
-lint:
-  name: yamllint
+lint: |
+  set -e
+  ansible-lint
 
 verifier:
   name: testinfra
@@ -48,5 +47,3 @@ verifier:
     s: true
   additional_files_or_dirs:
     - ../resources/tests/
-  lint:
-    name: flake8

--- a/molecule/layouts/playbook.yml
+++ b/molecule/layouts/playbook.yml
@@ -1,19 +1,15 @@
 ---
 
-- hosts: all
+- hosts: minio
   any_errors_fatal: true
+  vars_files:
+    - ./../resources/vars.yml
   vars:
-    minio_server_artifact_url: https://dl.min.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2020-10-28T08-16-50Z
-    minio_server_artifact_checksum: sha256:2c7e6774a9befbba6a126791f363550f8f14e34008e100d0e0e57e2ad9b2ab8c
-    minio_client_artifact_url: https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2020-10-03T02-54-56Z
-    minio_client_artifact_checksum: sha256:59e184bd4e2c3a8a19837b0f0da3977bd4e301495a24e4a5d50e291728a1de51
     minio_layouts:
       server1:
         server_addr: ":9091"
       server2:
         server_addr: ":9092"
-    minio_access_key: "key"
-    minio_secret_key: "seecreet"
   roles:
     - role: ansible-minio
       vars:

--- a/molecule/layouts/tests/test_minio_default.py
+++ b/molecule/layouts/tests/test_minio_default.py
@@ -6,16 +6,17 @@ import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+dir_path = os.path.dirname(os.path.abspath(__file__))
 
 
 @pytest.fixture()
 def AnsibleDefaults():
-    with open('../../defaults/main.yml', 'r') as stream:
+    with open(os.path.join(dir_path, './../../../defaults/main.yml'), 'r') as stream:
         return yaml.load(stream)
 
 @pytest.fixture()
 def AnsiblePlaybook():
-    with open('./playbook.yml', 'r') as stream:
+    with open(os.path.join(dir_path, './../playbook.yml'), 'r') as stream:
         return yaml.load(stream)
 
 
@@ -29,7 +30,7 @@ def test_minio_installed(host, AnsibleDefaults, minio_bin_var):
     assert f.exists
     assert f.user == 'root'
     assert f.group == 'root'
-    assert oct(f.mode) == '0755'
+    assert oct(f.mode) == '0o755'
 
 
 def test_minio_server_data_directory(host, AnsibleDefaults, AnsiblePlaybook):
@@ -43,7 +44,7 @@ def test_minio_server_data_directory(host, AnsibleDefaults, AnsiblePlaybook):
         assert d.exists
         assert d.user == AnsibleDefaults['minio_user']
         assert d.group == AnsibleDefaults['minio_group']
-        assert oct(d.mode) == '0750'
+        assert oct(d.mode) == '0o750'
 
 
 def test_minio_server_webservers(host, AnsibleDefaults):

--- a/molecule/resources/vars.yml
+++ b/molecule/resources/vars.yml
@@ -1,0 +1,2 @@
+minio_access_key: "key"
+minio_secret_key: "seecreet"

--- a/tasks/install-server.yml
+++ b/tasks/install-server.yml
@@ -157,6 +157,7 @@
     dest: "/etc/systemd/system/{{ _minio_service_name }}.service"
     owner: "root"
     group: "root"
+    mode: 0644
   when: ansible_service_mgr == "systemd"
   notify:
     - reload minio systemd

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,4 @@
-# NOTE: pin 'sh' due to https://github.com/ansible-community/molecule/issues/2676
-sh >=1.12.14, <1.13
-molecule >=2.15.0, <3.0.0
+molecule[docker] >=3.2, <3.3
 docker
-ansible-lint>=3.4.0
-testinfra>=1.7.0
+ansible-lint >=4.0, <5.0
+pytest-testinfra >=6.2, <7.0


### PR DESCRIPTION
* set role name explicitly to satisfy ansible-lint
* require Ansible >= 2.8
* ansible-lint is not latest because we depend of the Ansible version
  we depend on
* create and destroy playbooks are now provided by molecule-docker
* current working directory now is defined from where molecule is invoked,
  hence relative paths in python test scripts had to be adjusted so that
  they are still based on the script's location
* removed galaxy as dependency since the tests dont depend on any
* enabled the only linter that was already defined as dependency (requirements-test.txt)
* credentials for each scenario are defined in a single resources/vars.yml
* explicitly set mode attribute (default value if not set) to satisfy linter