### PR TITLE
Fix default download URL path

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,7 +8,7 @@ go_arch_map:
 
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
 
-minio_default_server_artifact_url: "https://dl.minio.io/server/minio/release/linux-{{ go_arch }}/minio"
-minio_default_client_artifact_url: "https://dl.minio.io/client/mc/release/linux-{{ go_arch }}/mc"
+minio_default_server_artifact_url: "https://dl.minio.io/server/minio/release/linux-{{ go_arch }}/archive/minio"
+minio_default_client_artifact_url: "https://dl.minio.io/client/mc/release/linux-{{ go_arch }}/archive/mc"
 
 minio_server_old_credentials_envfile: "{{ minio_server_envfile }}.pre"


### PR DESCRIPTION
# What's new in this PR?

### Issues

The download URL path for older versions seems to have changed. So, the download of artifacts results in a 404 for cases where a specific release version is being defined (see tasks *'Compose ... download url'*).

### Causes (Optional)

Apparently, things have been moved around on the download server.

### Solutions

Update the default download URL path to reflect the current reality.

### Dependencies (Optional)

*None*

### Needs releases with:

*None*

### Testing

By successfully applying the changed role to a cluster.

### Notes (Optional)

Note that if a release version is not defined explicitly, the proposed change still works, because the latest versions are placed in the archive folder, too.

### Attachments (Optional)

*None*
