### PR TITLE
Followup to #9 - set env vars

### DIFF
--- a/templates/minio.env.j2
+++ b/templates/minio.env.j2
@@ -1,5 +1,8 @@
 {{ ansible_managed | comment }}
 
+# Needed to to able to use root disks
+MINIO_CI_CD=1
+
 # Minio local/remote volumes.
 {% if minio_server_cluster_nodes | length > 0 %}
 MINIO_VOLUMES="{{ minio_server_cluster_nodes | join(' ') }}"
@@ -11,11 +14,13 @@ MINIO_OPTS="--address {{ minio_server_addr }} {{ minio_server_opts }}"
 
 {% if minio_access_key is defined and minio_access_key | length > 0 %}
 # Access Key of the server.
-MINIO_ACCESS_KEY="{{ minio_access_key }}"
+MINIO_ROOT_USER="{{ minio_access_key }}"
+MINIO_ACCESS_KEY_OLD="{{ minio_access_key }}"
 {% endif %}
 {% if minio_secret_key is defined and minio_secret_key | length > 0 %}
 # Secret key of the server.
-MINIO_SECRET_KEY="{{ minio_secret_key }}"
+MINIO_ROOT_PASSWORD="{{ minio_secret_key }}"
+MINIO_SECRET_KEY_OLD="{{ minio_secret_key }}"
 {% endif %}
 
 {{ minio_server_env_extra }}


### PR DESCRIPTION
Followup to #9. Adjust environment variable names. We also set `MINIO_CI_CD` in order to [disable the root disk check](https://github.com/minio/minio/pull/14232/).
