### PR TITLE
Update server binary checksum in test playbook.yml

### DIFF
--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -8,7 +8,7 @@
     - ./../resources/vars.yml
   vars:
     minio_server_artifact_url: https://dl.min.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2023-07-07T07-13-57Z
-    minio_server_artifact_checksum: sha256:15d762671436cf383f9cc6667260e6c1298c25c8d7009576f709c3823e4a494d
+    minio_server_artifact_checksum: sha256:f6d1aadf4baec1556880e659748d7fbc6bc8d2dac3554f816e95492d3881660a
     minio_client_artifact_url: https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2023-07-07T05-25-51Z
     minio_client_artifact_checksum: sha256:205a2dc5a49dc467f78228c43c7d368e376c6cc14492597a7c4fe195c291f074
     minio_server_envfile: "/opt/minio"


### PR DESCRIPTION
... since it's not the [right one](https://dl.min.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2023-07-07T07-13-57Z.sha256sum)
